### PR TITLE
Make changes to the structure of repo and add section for setup docs

### DIFF
--- a/process-outline/previous-program-docs/process-outline1.0.md
+++ b/process-outline/previous-program-docs/process-outline1.0.md
@@ -1,4 +1,5 @@
 # Tech For Better Project Process
+
 - Created by Joe & Simon of T4B1
 
 This outlines the overall recommended process for each Tech For Better (TFB) project. This is an ongoing process and open to iteration as further projects are delivered.
@@ -8,8 +9,8 @@ This outlines the overall recommended process for each Tech For Better (TFB) pro
 The following steps must take place before the project can begin
 
 - Project is to be selected from the TFB applicant backlog
-- Potential PO must have attended at least the ‘Discovery’ workshop
-- TFB London participants to host a ‘Definition’ workshop with the potential POs
+- Potential PO must have attended at least the [‘Discovery’ workshop](https://docs.google.com/presentation/d/1mW-O6DXU1HPS66gpfcO4peR1yBKlpowIS4zJKZlBbK8/edit#slide=id.g1e792c6c39_0_0)
+- TFB London participants to host a [‘Definition’ workshop](https://docs.google.com/presentation/d/1sHa-q5WrDiDP53ob-AVAKBKAFO5SOz2d6Z3XVDITza0/edit) with the potential POs
 - Once selected, all TFB participants have a 2-hour meeting without PO. In this meeting:
   London participants to provide and present a slide deck taking the Gaza participants through the project, including the problem, defined solution so far and potential scope discussed
 - All participants to fully understand the project and agree the general scope they are comfortable with in this meeting

--- a/process-outline/process-outline2.0.md
+++ b/process-outline/process-outline2.0.md
@@ -1,4 +1,5 @@
 # Tech For Better Project Process
+
 - An update on process-outline1.0 for Founders Programme 2
 
 This outlines the overall recommended process for each Tech For Better (TFB) project. This is an ongoing process and open to iteration as further projects are delivered.
@@ -8,8 +9,8 @@ This outlines the overall recommended process for each Tech For Better (TFB) pro
 The following steps must take place before the project can begin
 
 - Project is to be selected from the TFB applicant backlog
-- Potential PO must have attended at least the ‘Discovery’ workshop
-- TFB London participants to host a ‘Definition’ workshop with the potential POs. 
+- Potential PO must have attended at least the [‘Discovery’ workshop](https://docs.google.com/presentation/d/1mW-O6DXU1HPS66gpfcO4peR1yBKlpowIS4zJKZlBbK8/edit#slide=id.g1e792c6c39_0_0)
+- TFB London participants to host a [‘Definition’ workshop](https://docs.google.com/presentation/d/1sHa-q5WrDiDP53ob-AVAKBKAFO5SOz2d6Z3XVDITza0/edit) with the potential POs.
 
 edit: It is highly recommended that the definition workshop is completed before the first day of the Founders Programme
 
@@ -52,29 +53,27 @@ For marketing purposes and also for the funders of the project, it is important 
 
 ### Timings
 
-The project takes place over 4 working weeks. Working times can vary but generally they are (all times in GMT):
+The project takes place over 4 working weeks. Working times can vary but generally they are (all times in GMT and subject to change):
 
-- London: Monday to Friday 10am to 6pm
-
-    edit: for T4B2 we work 10:30am - 6:30pm
+- London: Monday to Friday 10:30am to 6:30pm
 
 - Gaza: Sunday to Thursday 6am to 2pm
-- Team stand up: Monday to Thursday at 10am
+- Team stand up: Monday to Thursday at 11am
 
-    edit: stand-ups at 11am for 1st project (Commons)
-          stand-up times for 2nd project (HOWL) tba due to time difference issue
+  edit: stand-ups at 11am for 1st project (Commons)
+  stand-up times for 2nd project (HOWL) tba due to time difference issue
 
 - Weekly retrospective: Thursday at 10.30am (straight after the stand up)
 
-    edit: weekly retrospective at 11:30am for Commons
+  edit: weekly retrospective at 11:30am for Commons
 
 - Code Sharing (Thurs at 11ish, after the retro)
 
-    edit: between 12-1 for Commmons
+  edit: between 12-1 for Commmons
 
 - One or more members present on something the others would like to learn or know about in the code base. This is a great way to learn throughout.
 - Daily Stand Up Log:
-- This is an Issue that you create in each project repo with the idea that everyone at the end of each day writes up what they did, what they plan to do and any blockers. This means there’s less issues with the team stand up happening midday Gaza time. 
+- This is an Issue that you create in each project repo with the idea that everyone at the end of each day writes up what they did, what they plan to do and any blockers. This means there’s less issues with the team stand up happening midday Gaza time.
 
 ### Schedule
 

--- a/setup/project-style.md
+++ b/setup/project-style.md
@@ -1,9 +1,9 @@
-# Project Style/Process Guide
-
 ## Overview:
+
 This issue is intended to document for our current processes within this project. Once everyone agrees on the document, contents should only be changed once discussed with and agreed by the whole team.
 
 ## Contents:
+
 - [Linting](#Linting)
 - [Naming Branches](#Naming-Branches)
 - [Commit messages](#Commit-Messages)
@@ -11,19 +11,21 @@ This issue is intended to document for our current processes within this project
 - [Merging Pull Requests](#Merging-Pull-Requests)
 
 ## Linting
+
 - To begin with, we would suggest using eslint with the airbnb style guide configuration for easy setup (to be done on one computer and added to project file)
 - Further edits to the linter configuration file can be discussed, agreed on, and documented here.
 
-
 ## Naming Branches
+
 - feature/fix convention
-    - E.g. ```feature/add-search-function``` or ```fix/change-searchbar-color```
+  - E.g. `feature/add-search-function` or `fix/change-searchbar-color`
 
 ## Commit Messages
+
 - Should include issue #
-- Written with 'imperative tone' to describe what a commit does, rather than what it did. 
-    - E.g. ```Change color of search bar``` instead of ```Changed/changes color of search bar```
-    
+- Written with 'imperative tone' to describe what a commit does, rather than what it did.
+  - E.g. `Change color of search bar` instead of `Changed/changes color of search bar`
+
 ## Pre Pull Request Checklist
 
 - [ ] **Branch is up to date with master**
@@ -56,4 +58,3 @@ This issue is intended to document for our current processes within this project
 ## Merging Pull Requests
 
 - The person that made the pull request is responsible for the final merge, but only after someone else from the team has reviewed, approved, and left a comment on the pull request to that affect
-

--- a/setup/standup-log.md
+++ b/setup/standup-log.md
@@ -1,0 +1,9 @@
+In this issue, at the end of each working day, please add a comment answering the following questions. These will form the basis of the standup meeting each day:
+
+### **Date:**
+
+### **What issue(s) did I work on today?**
+
+### **What issue do I plan to work on tomorrow?**
+
+### **Am I facing any blockers?**

--- a/setup/user-manuals.md
+++ b/setup/user-manuals.md
@@ -1,0 +1,54 @@
+Taken from Founders & Coders...
+
+# User Manuals
+
+Personal user manuals! Keep them updated, read them well 📒
+
+![The Pink Panther reading a book](https://media.giphy.com/media/ZCmDhIFeF1s2c/giphy.gif)
+
+## How do I edit my user manual?
+
+Your manuals are all in this repo as issues. Click on the 'issues' tab above to see them all.
+Find your own, and click the `...` in the top right of the comment to edit it and add your info.
+We will make time regularly to go back and edit this info, so don't worry if you can't think of incredibly insightful things to write at first, but do try to fill in as much as you can.
+
+## Why are we doing this?
+
+It's a great way to think about ourselves and how we work in a team. It's also a great way to find out about our team-mates before working together so we know how to get the best out of each other and work well as a team 👭👬
+
+---
+
+<!--
+Add your information. Have a think, try to make it useful.
+
+You can format text using markdown:
+https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
+
+If you've added lots of info and you'd like to jazz it up:
+
+You can add emojis to your markdown! 👻
+https://gist.github.com/roachhd/1f029bd4b50b8a524f3c
+Also, on MacOs, ctrl+cmd+space opens an emoji menu
+
+You can add cool GIFs to your markdown!
+giphy.com has a lot of GIFs. You can add images with the following markdown code:
+![alt text](url)
+-->
+
+# @handle
+
+Name:
+
+## How I get my best work done:
+
+## The role I usually take in a team:
+
+## My communication style:
+
+## What I value:
+
+## What people misunderstand about me:
+
+## How I like to get my feedback:
+
+## Tech Stack:


### PR DESCRIPTION
I added a section for setup docs including a lot of the stuff that we went over today (Monday), as well as other things like the template for daily standups and user manuals. The idea is that there will be a section of the repo dedicated to all of the things that we need to set up for each project.

I also moved the original process document into a separate folder for 'old' documentation, so that we can edit the other one more without worrying about changing things.

Just trying to keep things organized as we go to make life easier! Trying to think about converting the process doc into a checklist so that it's something that we can follow along at the start of a project, but I think that's something for later.

:shipit: 